### PR TITLE
AirのURLの修正

### DIFF
--- a/.docker/app/local.Dockerfile
+++ b/.docker/app/local.Dockerfile
@@ -1,6 +1,6 @@
-FROM golang:1.22.2 AS app
+FROM golang:1.24.4 AS app
 WORKDIR /app
 
-RUN go install github.com/cosmtrek/air@latest
+RUN go install github.com/air-verse/air@latest
 
 CMD ["air","-c",".docker/app/.air.toml"]


### PR DESCRIPTION
## 変更点
- ローカル動作用のデバッグDockerfileで利用しているAirのURLが古いままになっていたので修正
- Dockerfileのgolangバージョンを1.24.4にアップデート


## 破壊的変更
無し