### PR TITLE
環境変数に応じてcategoryをprivateにできるようにした

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Application Env
 ENV=dev
+ENABLE_PRIVATE_CATEGORY=false # 作成するカテゴリーをチームごとにプライベートにするか
 
 # Google Env
 GOOGLE_SPREADSHEET_ID=


### PR DESCRIPTION
# what
カテゴリ作成時に、各チームでプライベートなカテゴリを立てられるようにした

# how
環境変数 `ENABLE_PRIVATE_CATEGORY` を true にした状態で作成を実行することで、
- @everyone: アクセス不可
- チームメンバー・メンター: アクセス可
なカテゴリを作るようになります