### PR TITLE
feat: add mute role permission support via VORTEX_MUTEROLE_ID

### DIFF
--- a/cmd/sheet-to-discord/main.go
+++ b/cmd/sheet-to-discord/main.go
@@ -144,7 +144,14 @@ func buildVCPermissionOverwrites(participantsRoleID, mentorRoleID, guildID strin
 	return overwrites
 }
 
-func buildCategoryPermissionOverwrites(teamRoleID, mentorRoleID, guildID string) []*discordgo.PermissionOverwrite {
+const muteRoleDeny = discordgo.PermissionSendMessages |
+	discordgo.PermissionCreatePublicThreads |
+	discordgo.PermissionCreatePrivateThreads |
+	discordgo.PermissionAddReactions |
+	discordgo.PermissionVoiceConnect |
+	discordgo.PermissionVoiceSpeak
+
+func buildCategoryPermissionOverwrites(teamRoleID, mentorRoleID, guildID, muteRoleID string) []*discordgo.PermissionOverwrite {
 	overwrites := []*discordgo.PermissionOverwrite{
 		{
 			// @everyone
@@ -167,6 +174,14 @@ func buildCategoryPermissionOverwrites(teamRoleID, mentorRoleID, guildID string)
 			Deny:  0,
 			Allow: discordgo.PermissionViewChannel,
 		},
+	}
+	if muteRoleID != "" {
+		overwrites = append(overwrites, &discordgo.PermissionOverwrite{
+			ID:    muteRoleID,
+			Type:  discordgo.PermissionOverwriteTypeRole,
+			Deny:  muteRoleDeny,
+			Allow: 0,
+		})
 	}
 	return overwrites
 }
@@ -219,6 +234,7 @@ func main() {
 	eventName := os.Getenv("EVENT_NAME")
 	enablePrivateVC := getenvBool("PRIVATE_VC", false)
 	enablePrivateCategory := getenvBool("PRIVATE_CATEGORY", false)
+	muteRoleID := os.Getenv("VORTEX_MUTEROLE_ID")
 
 	if spreadsheetID == "" || botToken == "" || guildID == "" || credentialsFile == "" || teamRange == "" || eventName == "" {
 		log.Fatal("One or more required environment variables are not set.")
@@ -300,7 +316,7 @@ func main() {
 		// カテゴリの権限設定
 		categoryOverwrites := buildPublicPermissionOverwrites(guildID)
 		if enablePrivateCategory {
-			categoryOverwrites = buildCategoryPermissionOverwrites(roleID, mentorRoleId, guildID)
+			categoryOverwrites = buildCategoryPermissionOverwrites(roleID, mentorRoleId, guildID, muteRoleID)
 			// vc権限をカテゴリ権限で上書き
 			vcOverwrites = categoryOverwrites
 		}


### PR DESCRIPTION
## Summary

- `VORTEX_MUTEROLE_ID` 環境変数でミュートロールのIDを指定できるようにした
- `buildCategoryPermissionOverwrites` にミュートロール用の deny overwrite を追加（環境変数が未設定の場合はスキップ）
- deny 対象権限: メッセージの送信・公開スレッドの作成・プライベートスレッドの作成・リアクションの追加・VC接続・VC発言

## Behavior

- `VORTEX_MUTEROLE_ID` が設定されていない場合: 既存の動作と変わらない
- `VORTEX_MUTEROLE_ID` が設定されている場合: `PRIVATE_CATEGORY=true` のとき、カテゴリ・テキストチャンネル・VCチャンネル全てにミュートロールの deny が適用される（テキスト/VCはカテゴリ権限に同期）

## Test plan

- [ ] `VORTEX_MUTEROLE_ID` 未設定で実行し、既存の権限設定が変わらないことを確認
- [ ] `VORTEX_MUTEROLE_ID=1163631665441149068` を設定して実行し、対象ロールに deny が付与されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)