### PR TITLE
docs: update README for new hackathon-util CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ YAMLマニフェストとサブコマンドで操作する新しいCLI。`create
 # チャンネル・ロールを作成
 go run cmd/hackathon-util/main.go -f example.yaml create
 
-# ドライラン（デフォルト）: 削除対象を確認するだけで実際には削除しない
+# ドライラン（デフォルト: --dry-run=true）: 削除対象を確認するだけで実際には削除しない
 go run cmd/hackathon-util/main.go -f example.yaml delete
 
 # 実際に削除
 go run cmd/hackathon-util/main.go -f example.yaml delete --dry-run=false
 
 # 参加者ロールからもメンバーを剥奪する場合
-go run cmd/hackathon-util/main.go -f example.yaml delete --dry-run=false --remove-all-members
+go run cmd/hackathon-util/main.go -f example.yaml delete --dry-run=false --remove-all-members=true
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ YAMLマニフェストとサブコマンドで操作する新しいCLI。`create
   - スプレッドシートに記載されたチームのカテゴリ・配下チャンネルを削除
   - チームロールをメンバーから剥奪し、ロール自体を削除
   - `--remove-all-members` で全参加者ロール `@参加者_{EVENT_NAME}` からメンバーを剥奪（ロール自体は削除しない）
-  - `--dry-run`（デフォルト: `true`）で実際の削除を行わず対象を確認できる
+  - `--dry-run` で実際の削除を行わず対象を確認できる（デフォルト: `false`）
 
 **YAMLマニフェストによる権限設定:**
 
@@ -46,14 +46,20 @@ YAMLマニフェストとサブコマンドで操作する新しいCLI。`create
 # チャンネル・ロールを作成
 go run cmd/hackathon-util/main.go -f example.yaml create
 
-# ドライラン（デフォルト: --dry-run=true）: 削除対象を確認するだけで実際には削除しない
-go run cmd/hackathon-util/main.go -f example.yaml delete
+# ドライラン: 実際のAPIで確認しつつ書き込みはスキップ
+go run cmd/hackathon-util/main.go -f example.yaml create --dry-run
+
+# チャンネル・ロールを作成
+go run cmd/hackathon-util/main.go -f example.yaml create
+
+# ドライラン: 実際のAPIで確認しつつ削除はスキップ
+go run cmd/hackathon-util/main.go -f example.yaml delete --dry-run
 
 # 実際に削除
-go run cmd/hackathon-util/main.go -f example.yaml delete --dry-run=false
+go run cmd/hackathon-util/main.go -f example.yaml delete
 
 # 参加者ロールからもメンバーを剥奪する場合
-go run cmd/hackathon-util/main.go -f example.yaml delete --dry-run=false --remove-all-members=true
+go run cmd/hackathon-util/main.go -f example.yaml delete --remove-all-members=true
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -8,31 +8,61 @@
 
 ## 提供ツール
 
-### cmd/sheet-to-discord
+### cmd/hackathon-util（推奨）
 
-Googleスプレッドシートからチーム情報を読み取り、Discordにロール・カテゴリ・チャンネルを自動生成するスクリプト
+YAMLマニフェストとサブコマンドで操作する新しいCLI。`create` と `delete` の2つのサブコマンドを持つ。
 
 **機能:**
-- 全参加者用の共通ロール `@参加者_{EVENT_NAME}` の作成・付与
-- メンター用ロール `@メンター_{EVENT_NAME}` の作成（色: #3498db）
-- チームごとのロール作成
-- チームごとのカテゴリ作成（テキストチャンネル「やりとり」とボイスチャンネル「会話」を含む）
-  - カテゴリ・チャンネルがすでに存在する場合は権限のみ更新
-  - `PRIVATE_VC=true` でボイスチャンネル「会話」を参加者ロール・メンターロール保持者のみに表示
-  - `PRIVATE_CATEGORY=true` でカテゴリ全体をチームロール・メンターロール保持者のみに表示
-  - `VORTEX_MUTEROLE_ID` を設定すると、そのロールに対してメッセージ送信・リアクション・VC接続などを禁止
-- スプレッドシートの各行 B〜F列のユーザー名（最大5名）にチームロールと参加者ロールを付与
-- Discord上に存在しないユーザーの一覧を実行後に表示
+- `create` サブコマンド
+  - 全参加者用の共通ロール `@参加者_{EVENT_NAME}` の作成・付与
+  - メンター用ロール `@メンター_{EVENT_NAME}` の作成（色: #3498db）
+  - チームごとのロール作成
+  - チームごとのカテゴリ作成（テキストチャンネル「やりとり」とボイスチャンネル「会話」を含む）
+    - カテゴリ・チャンネルがすでに存在する場合は権限のみ更新
+    - `enablePrivateVC: true` でボイスチャンネル「会話」を参加者ロール・メンターロール保持者のみに表示
+    - `enablePrivateCategory: true` でカテゴリ全体をチームロール・メンターロール保持者のみに表示
+    - `muteRoleID` を設定すると、そのロールに対してメッセージ送信・リアクション・VC接続などを禁止
+  - スプレッドシートの各行 B〜F列のユーザー名（最大5名）にチームロールと参加者ロールを付与
+  - Discord上に存在しないユーザーの一覧を実行後に表示
+- `delete` サブコマンド
+  - スプレッドシートに記載されたチームのカテゴリ・配下チャンネルを削除
+  - チームロールをメンバーから剥奪し、ロール自体を削除
+  - `--remove-all-members` で全参加者ロール `@参加者_{EVENT_NAME}` からメンバーを剥奪（ロール自体は削除しない）
+  - `--dry-run`（デフォルト: `true`）で実際の削除を行わず対象を確認できる
 
-**環境変数による権限設定:**
+**YAMLマニフェストによる権限設定:**
 
-| `PRIVATE_CATEGORY` | `PRIVATE_VC` | `#やりとり`                   | `#会話`                       |
-| ------------------ | ------------ | ----------------------------- | ----------------------------- |
-| `false`            | `false`      | `@everyone`                   | `@everyone`                   |
-| `false`            | `true`       | `@everyone`                   | 参加者ロール + メンターロール |
-| `true`             | true/false   | チームロール + メンターロール | チームロール + メンターロール |
+| `enablePrivateCategory` | `enablePrivateVC` | `#やりとり`                   | `#会話`                       |
+| ----------------------- | ----------------- | ----------------------------- | ----------------------------- |
+| `false`                 | `false`           | `@everyone`                   | `@everyone`                   |
+| `false`                 | `true`            | `@everyone`                   | 参加者ロール + メンターロール |
+| `true`                  | true/false        | チームロール + メンターロール | チームロール + メンターロール |
 
-※ `PRIVATE_CATEGORY=true` の場合、`PRIVATE_VC` の設定は上書きされます
+※ `enablePrivateCategory: true` の場合、`enablePrivateVC` の設定は上書きされます
+
+**実行方法:**
+
+```bash
+# チャンネル・ロールを作成
+go run cmd/hackathon-util/main.go -f example.yaml create
+
+# ドライラン（デフォルト）: 削除対象を確認するだけで実際には削除しない
+go run cmd/hackathon-util/main.go -f example.yaml delete
+
+# 実際に削除
+go run cmd/hackathon-util/main.go -f example.yaml delete --dry-run=false
+
+# 参加者ロールからもメンバーを剥奪する場合
+go run cmd/hackathon-util/main.go -f example.yaml delete --dry-run=false --remove-all-members
+```
+
+---
+
+### cmd/sheet-to-discord（旧実装）
+
+> **非推奨:** 新しい `cmd/hackathon-util` の使用を推奨します。
+
+Googleスプレッドシートからチーム情報を読み取り、Discordにロール・カテゴリ・チャンネルを自動生成するスクリプト
 
 **実行方法:**
 
@@ -49,15 +79,11 @@ PRIVATE_CATEGORY=true go run cmd/sheet-to-discord/main.go
 
 ---
 
-### cmd/sheet-to-discord-delete
+### cmd/sheet-to-discord-delete（旧実装）
+
+> **非推奨:** 新しい `cmd/hackathon-util` の使用を推奨します。
 
 ハッカソン終了後のクリーンアップ用スクリプト
-
-**機能:**
-- スプレッドシートに記載されたチームのカテゴリ・配下チャンネルを削除
-- チームロールをメンバーから剥奪し、ロール自体を削除
-- `REMOVE_ALL_MEMBERS=true` で全参加者ロール `@参加者_{EVENT_NAME}` からメンバーを剥奪（ロール自体は削除しない）
-- `DRY_RUN=true`（デフォルト）で実際の削除を行わず対象を確認できる
 
 **実行方法:**
 
@@ -76,6 +102,27 @@ DRY_RUN=false REMOVE_ALL_MEMBERS=true go run cmd/sheet-to-discord-delete/main.go
 
 ## セットアップ
 
+### YAMLマニフェストを作成
+
+`example.yaml` をコピーして編集する。
+
+```bash
+cp example.yaml config.yaml
+```
+
+```yaml
+eventName: "hoge"
+googleSheet:
+  id: "hoge"
+  teamTableRange: "hoge!A:Z"
+  credentialFile: "./credential.json"
+discord:
+  guildID: "hoge"
+  muteRoleID: "hoge"       # 省略可
+  enablePrivateVC: false
+  enablePrivateCategory: false
+```
+
 ### 環境変数を設定
 
 ```bash
@@ -86,17 +133,17 @@ cp .env.example .env
 
 | 変数名 | 必須 | 説明 |
 |---|---|---|
-| `GOOGLE_SPREADSHEET_ID` | ✅ | 対象のスプレッドシートID |
-| `TEAM_RANGE` | ✅ | チーム情報の範囲（例: `チームシート!A2:F15`） |
-| `GOOGLE_CREDENTIALS_FILE` | ✅ | Google認証情報ファイルのパス |
-| `EVENT_NAME` | ✅ | イベント名。参加者・メンターロール名のサフィックスに使用 |
 | `DISCORD_BOT_TOKEN` | ✅ | DiscordのBotトークン |
-| `DISCORD_GUILD_ID` | ✅ | 対象のDiscordサーバーID |
-| `PRIVATE_VC` | - | `true` でボイスチャンネルをプライベートにする（デフォルト: `false`） |
-| `PRIVATE_CATEGORY` | - | `true` でカテゴリをプライベートにする（デフォルト: `false`） |
-| `VORTEX_MUTEROLE_ID` | - | ミュートロールのID。設定するとそのロールの発言・VC接続を禁止 |
-| `DRY_RUN` | - | `sheet-to-discord-delete` 用。`false` で実際に削除（デフォルト: `true`） |
-| `REMOVE_ALL_MEMBERS` | - | `sheet-to-discord-delete` 用。`true` で参加者ロールからもメンバーを剥奪（デフォルト: `false`） |
+| `GOOGLE_SPREADSHEET_ID` | ※旧実装のみ | 対象のスプレッドシートID |
+| `TEAM_RANGE` | ※旧実装のみ | チーム情報の範囲（例: `チームシート!A2:F15`） |
+| `GOOGLE_CREDENTIALS_FILE` | ※旧実装のみ | Google認証情報ファイルのパス |
+| `EVENT_NAME` | ※旧実装のみ | イベント名。参加者・メンターロール名のサフィックスに使用 |
+| `DISCORD_GUILD_ID` | ※旧実装のみ | 対象のDiscordサーバーID |
+| `PRIVATE_VC` | ※旧実装のみ | `true` でボイスチャンネルをプライベートにする（デフォルト: `false`） |
+| `PRIVATE_CATEGORY` | ※旧実装のみ | `true` でカテゴリをプライベートにする（デフォルト: `false`） |
+| `VORTEX_MUTEROLE_ID` | ※旧実装のみ | ミュートロールのID。設定するとそのロールの発言・VC接続を禁止 |
+| `DRY_RUN` | ※旧実装のみ | `sheet-to-discord-delete` 用。`false` で実際に削除（デフォルト: `true`） |
+| `REMOVE_ALL_MEMBERS` | ※旧実装のみ | `sheet-to-discord-delete` 用。`true` で参加者ロールからもメンバーを剥奪（デフォルト: `false`） |
 
 ### スプレッドシートのフォーマット
 

--- a/cmd/hackathon-util/main.go
+++ b/cmd/hackathon-util/main.go
@@ -44,7 +44,9 @@ func main() {
 
 // newCreateCmd builds the "create" sub-command.
 func newCreateCmd(manifestFile *string) *cobra.Command {
-	return &cobra.Command{
+	var dryRun bool
+
+	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create Discord roles, categories, and channels from a Google Sheet",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -60,10 +62,14 @@ func newCreateCmd(manifestFile *string) *cobra.Command {
 
 			return create.Run(create.Config{
 				BotToken: botToken,
+				DryRun:   dryRun,
 				Cfg:      cfg,
 			})
 		},
 	}
+
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "preview changes without applying them (reads from Discord/Sheets API but skips writes)")
+	return cmd
 }
 
 // newDeleteCmd builds the "delete" sub-command.
@@ -94,7 +100,7 @@ func newDeleteCmd(manifestFile *string) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVar(&dryRun, "dry-run", true, "preview changes without applying them")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "preview changes without applying them (reads from Discord/Sheets API but skips writes)")
 	cmd.Flags().BoolVar(&removeAllMembers, "remove-all-members", false, "also remove the participants role from all members")
 
 	return cmd

--- a/internal/command/create/channel.go
+++ b/internal/command/create/channel.go
@@ -14,28 +14,34 @@ func ensureTeamCategory(
 	cfg *config.Config,
 	teamName string,
 	categoryOverwrites, vcOverwrites []*discordgo.PermissionOverwrite,
+	dryRun bool,
 ) bool {
-	categoryID, ok := upsertCategory(gs, cfg.Discord.GuildID, teamName, categoryOverwrites)
+	categoryID, ok := upsertCategory(gs, cfg.Discord.GuildID, teamName, categoryOverwrites, dryRun)
 	if !ok {
 		return false
 	}
-	upsertChildChannel(gs, cfg.Discord.GuildID, teamName, categoryID, "やりとり", discordgo.ChannelTypeGuildText, categoryOverwrites)
-	upsertChildChannel(gs, cfg.Discord.GuildID, teamName, categoryID, "会話", discordgo.ChannelTypeGuildVoice, vcOverwrites)
+	upsertChildChannel(gs, cfg.Discord.GuildID, teamName, categoryID, "やりとり", discordgo.ChannelTypeGuildText, categoryOverwrites, dryRun)
+	upsertChildChannel(gs, cfg.Discord.GuildID, teamName, categoryID, "会話", discordgo.ChannelTypeGuildVoice, vcOverwrites, dryRun)
 	return true
 }
 
 // upsertCategory creates the category if absent, otherwise updates its permissions.
-// Returns (categoryID, true) on success.
-func upsertCategory(gs *guildState, guildID, teamName string, overwrites []*discordgo.PermissionOverwrite) (string, bool) {
+// Returns (categoryID, true) on success. In dry-run mode writes are skipped.
+func upsertCategory(gs *guildState, guildID, teamName string, overwrites []*discordgo.PermissionOverwrite, dryRun bool) (string, bool) {
 	if id, exists := gs.existingCategories[teamName]; exists {
-		if err := updateChannelPermissions(gs.dg, id, overwrites); err != nil {
+		if dryRun {
+			slog.Info("dry run: would update category permission", slog.String("team", teamName))
+		} else if err := updateChannelPermissions(gs.dg, id, overwrites); err != nil {
 			slog.Error("update category permission failed", slog.String("team", teamName), slog.String("error.message", err.Error()))
 		} else {
 			slog.Info("category permission updated", slog.String("team", teamName))
 		}
 		return id, true
 	}
-
+	if dryRun {
+		slog.Info("dry run: would create category", slog.String("team", teamName))
+		return "", true
+	}
 	ch, err := gs.dg.GuildChannelCreateComplex(guildID, discordgo.GuildChannelCreateData{
 		Name:                 teamName,
 		Type:                 discordgo.ChannelTypeGuildCategory,
@@ -51,21 +57,28 @@ func upsertCategory(gs *guildState, guildID, teamName string, overwrites []*disc
 }
 
 // upsertChildChannel updates permissions if the channel exists, otherwise creates it.
+// In dry-run mode writes are skipped.
 func upsertChildChannel(
 	gs *guildState,
 	guildID, teamName, categoryID, name string,
 	chType discordgo.ChannelType,
 	overwrites []*discordgo.PermissionOverwrite,
+	dryRun bool,
 ) {
 	if id := findChildChannelID(gs.channels, categoryID, name, chType); id != "" {
-		if err := updateChannelPermissions(gs.dg, id, overwrites); err != nil {
+		if dryRun {
+			slog.Info("dry run: would update channel permission", slog.String("team", teamName), slog.String("channel", name))
+		} else if err := updateChannelPermissions(gs.dg, id, overwrites); err != nil {
 			slog.Error("update channel permission failed", slog.String("team", teamName), slog.String("channel", name), slog.String("error.message", err.Error()))
 		} else {
 			slog.Info("channel permission updated", slog.String("team", teamName), slog.String("channel", name))
 		}
 		return
 	}
-
+	if dryRun {
+		slog.Info("dry run: would create channel", slog.String("team", teamName), slog.String("channel", name))
+		return
+	}
 	if _, err := gs.dg.GuildChannelCreateComplex(guildID, discordgo.GuildChannelCreateData{
 		Name:                 name,
 		Type:                 chType,

--- a/internal/command/create/create.go
+++ b/internal/command/create/create.go
@@ -12,6 +12,7 @@ import (
 // Config holds runtime options for the create command.
 type Config struct {
 	BotToken string
+	DryRun   bool
 	Cfg      *config.Config
 }
 
@@ -44,17 +45,17 @@ func Run(cc Config) error {
 		return err
 	}
 
-	baseVCOverwrites, participantsRoleID, mentorRoleID := buildBaseOverwrites(dg, cfg, gs)
+	baseVCOverwrites, participantsRoleID, mentorRoleID := buildBaseOverwrites(dg, cfg, gs, cc.DryRun)
 
-	notFoundUsers := processAllTeams(gs, cfg, teamData, mentorRoleID, participantsRoleID, baseVCOverwrites)
+	notFoundUsers := processAllTeams(gs, cfg, teamData, mentorRoleID, participantsRoleID, baseVCOverwrites, cc.DryRun)
 	logNotFoundUsers(notFoundUsers)
 	return nil
 }
 
 // buildBaseOverwrites creates the participants/mentor roles and returns the base VC permission overwrites.
-func buildBaseOverwrites(dg *discordgo.Session, cfg *config.Config, gs *guildState) ([]*discordgo.PermissionOverwrite, string, string) {
+func buildBaseOverwrites(dg *discordgo.Session, cfg *config.Config, gs *guildState, dryRun bool) ([]*discordgo.PermissionOverwrite, string, string) {
 	mentionable := true
-	participantsRoleID, mentorRoleID, _ := createParticipantsRole(dg, cfg.Discord.GuildID, cfg.EventName, gs.existingRoles, mentionable)
+	participantsRoleID, mentorRoleID, _ := createParticipantsRole(dg, cfg.Discord.GuildID, cfg.EventName, gs.existingRoles, mentionable, dryRun)
 
 	baseVCOverwrites := buildPublicPermissionOverwrites(cfg.Discord.GuildID)
 	if cfg.Discord.EnablePrivateVC {
@@ -71,6 +72,7 @@ func processAllTeams(
 	teamData [][]any,
 	mentorRoleID, participantsRoleID string,
 	baseVCOverwrites []*discordgo.PermissionOverwrite,
+	dryRun bool,
 ) []string {
 	mentionable := true
 	var notFoundUsers []string
@@ -82,7 +84,7 @@ func processAllTeams(
 		if teamName == "" {
 			continue
 		}
-		missing := processTeamRow(gs, cfg, row, teamName, mentorRoleID, participantsRoleID, baseVCOverwrites, mentionable)
+		missing := processTeamRow(gs, cfg, row, teamName, mentorRoleID, participantsRoleID, baseVCOverwrites, mentionable, dryRun)
 		notFoundUsers = append(notFoundUsers, missing...)
 		slog.Info("team processed", slog.String("team", teamName))
 	}

--- a/internal/command/create/role.go
+++ b/internal/command/create/role.go
@@ -11,23 +11,28 @@ import (
 const mentorRoleColor = 3447003
 
 // createParticipantsRole ensures the participants and mentor roles exist.
-func createParticipantsRole(dg *discordgo.Session, guildID, eventName string, existingRoles map[string]string, mentionable bool) (string, string, error) {
+func createParticipantsRole(dg *discordgo.Session, guildID, eventName string, existingRoles map[string]string, mentionable bool, dryRun bool) (string, string, error) {
 	participantsRoleID := ensureRole(dg, guildID, "参加者_"+eventName, existingRoles, &discordgo.RoleParams{
 		Mentionable: &mentionable,
-	})
+	}, dryRun)
 	color := mentorRoleColor
 	mentorRoleID := ensureRole(dg, guildID, "メンター_"+eventName, existingRoles, &discordgo.RoleParams{
 		Mentionable: &mentionable,
 		Color:       &color,
-	})
+	}, dryRun)
 	return participantsRoleID, mentorRoleID, nil
 }
 
 // ensureRole returns the existing role ID or creates a new one.
-func ensureRole(dg *discordgo.Session, guildID, roleName string, existingRoles map[string]string, params *discordgo.RoleParams) string {
+// In dry-run mode the API call is skipped and an empty string is returned for new roles.
+func ensureRole(dg *discordgo.Session, guildID, roleName string, existingRoles map[string]string, params *discordgo.RoleParams, dryRun bool) string {
 	if id := existingRoles[roleName]; id != "" {
 		slog.Info("role already exists, skipping", slog.String("role", roleName))
 		return id
+	}
+	if dryRun {
+		slog.Info("dry run: would create role", slog.String("role", roleName))
+		return ""
 	}
 	params.Name = roleName
 	role, err := dg.GuildRoleCreate(guildID, params)
@@ -40,7 +45,8 @@ func ensureRole(dg *discordgo.Session, guildID, roleName string, existingRoles m
 }
 
 // assignRoleIfMissing assigns roleID to the user if they don't already have it.
-func assignRoleIfMissing(dg *discordgo.Session, guildID, userID, roleID, username string) error {
+// In dry-run mode the member is still fetched but the role assignment is skipped.
+func assignRoleIfMissing(dg *discordgo.Session, guildID, userID, roleID, username string, dryRun bool) error {
 	member, err := dg.GuildMember(guildID, userID)
 	if err != nil || member == nil {
 		slog.Info("could not retrieve member, skipping", slog.String("username", username), slog.String("role_id", roleID))
@@ -52,6 +58,10 @@ func assignRoleIfMissing(dg *discordgo.Session, guildID, userID, roleID, usernam
 			return nil
 		}
 	}
+	if dryRun {
+		slog.Info("dry run: would assign role", slog.String("role_id", roleID), slog.String("username", username))
+		return nil
+	}
 	if err := dg.GuildMemberRoleAdd(guildID, userID, roleID); err != nil {
 		return err
 	}
@@ -61,7 +71,7 @@ func assignRoleIfMissing(dg *discordgo.Session, guildID, userID, roleID, usernam
 
 // assignRoleToRowMembers assigns roleID to every member listed in columns B–F.
 // Returns usernames that could not be found in userMap.
-func assignRoleToRowMembers(gs *guildState, row []any, roleID string, userMap map[string]string) []string {
+func assignRoleToRowMembers(gs *guildState, row []any, roleID string, userMap map[string]string, dryRun bool) []string {
 	var notFound []string
 	for i := 1; i <= 5; i++ {
 		username := columnUsername(row, i)
@@ -74,7 +84,7 @@ func assignRoleToRowMembers(gs *guildState, row []any, roleID string, userMap ma
 			notFound = append(notFound, username)
 			continue
 		}
-		if err := assignRoleIfMissing(gs.dg, gs.guildID, userID, roleID, username); err != nil {
+		if err := assignRoleIfMissing(gs.dg, gs.guildID, userID, roleID, username, dryRun); err != nil {
 			slog.Error("failed to assign role", slog.String("role_id", roleID), slog.String("username", username), slog.String("error.message", err.Error()))
 		}
 	}

--- a/internal/command/create/team.go
+++ b/internal/command/create/team.go
@@ -16,15 +16,16 @@ func processTeamRow(
 	teamName, mentorRoleID, participantsRoleID string,
 	baseVCOverwrites []*discordgo.PermissionOverwrite,
 	mentionable bool,
+	dryRun bool,
 ) []string {
-	roleID, ok := ensureTeamRole(gs, teamName, mentionable)
+	roleID, ok := ensureTeamRole(gs, teamName, mentionable, dryRun)
 	if !ok {
 		return nil
 	}
 
 	vcOverwrites, categoryOverwrites := buildTeamOverwrites(cfg, gs.guildID, roleID, mentorRoleID, baseVCOverwrites)
 
-	if !ensureTeamCategory(gs, cfg, teamName, categoryOverwrites, vcOverwrites) {
+	if !ensureTeamCategory(gs, cfg, teamName, categoryOverwrites, vcOverwrites, dryRun) {
 		return nil
 	}
 
@@ -35,17 +36,21 @@ func processTeamRow(
 		return nil
 	}
 
-	teamMissing := assignRoleToRowMembers(gs, row, roleID, userMap)
-	participantsMissing := assignRoleToRowMembers(gs, row, participantsRoleID, userMap)
+	teamMissing := assignRoleToRowMembers(gs, row, roleID, userMap, dryRun)
+	participantsMissing := assignRoleToRowMembers(gs, row, participantsRoleID, userMap, dryRun)
 	return append(teamMissing, participantsMissing...)
 }
 
 // ensureTeamRole returns the role ID for teamName, creating it if necessary.
 // Returns ("", false) on error.
-func ensureTeamRole(gs *guildState, teamName string, mentionable bool) (string, bool) {
+func ensureTeamRole(gs *guildState, teamName string, mentionable bool, dryRun bool) (string, bool) {
 	if id, exists := gs.existingRoles[teamName]; exists {
 		slog.Info("role already exists, skipping", slog.String("team", teamName))
 		return id, true
+	}
+	if dryRun {
+		slog.Info("dry run: would create role", slog.String("team", teamName))
+		return "", true
 	}
 	role, err := gs.dg.GuildRoleCreate(gs.guildID, &discordgo.RoleParams{
 		Name:        teamName,


### PR DESCRIPTION
## 概要

新しい `cmd/hackathon-util` CLIに合わせてREADMEを更新。

## 変更内容

- `cmd/hackathon-util` を推奨ツールとして先頭に移動
  - YAMLマニフェストの書き方を追記
  - `create` / `delete` サブコマンドとフラグの使い方を追記
  - 権限設定テーブル（`enablePrivateVC` / `enablePrivateCategory`）を追加
- `cmd/sheet-to-discord` / `cmd/sheet-to-discord-delete` を旧実装・非推奨として明記
- 環境変数一覧に「旧実装のみ」の注記を追加

## テスト

ドキュメントのみの変更のため、動作確認不要。